### PR TITLE
hotfix: change the text and adjust partnerships styles in small screen

### DIFF
--- a/src/components/footer/FooterBrand.tsx
+++ b/src/components/footer/FooterBrand.tsx
@@ -7,8 +7,9 @@ const FooterBrand = () => {
     <div className="s:col-span-3 s:mb-12 s:w-full">
       <Logo />
       <div className="FooterBrand_content mx-auto mt-6 font-poppins text-sm text-left text-white opacity-50 s:w-80">
-        Ref Finance is one of the core projects in the DeFi ecosystem on NEAR Protocol. Ref aims to bring DeFi one step
-        closer to the people. to {'>'} Multi-purpose DeFi platform built on NEAR Protocol
+        Multi-purpose DeFi platform built on
+        <br />
+        NEAR Protocol
       </div>
       <div className="s:hidden">
         <CommunityIcons />

--- a/src/index.html
+++ b/src/index.html
@@ -4,8 +4,6 @@
     <title>Ref.finance</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=no" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="icon" href="./assets/favicon.ico" />
   </head>
   <body>

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins');
+
+@import url('https://fonts.googleapis.com/css2?family=Lexend+Deca');
+
 @tailwind base;
 
 @tailwind components;

--- a/src/pages/home/Cooperation/Cards.tsx
+++ b/src/pages/home/Cooperation/Cards.tsx
@@ -5,42 +5,41 @@ const Cards = () => {
   return (
     <div className="grid grid-cols-4 gap-6 mt-10 s:grid-cols-2">
       {cooperations.map(({ icon, title }) => (
-        <div className="CooperateCard relative flex flex-col items-center pt-5 l:w-56 h-32 s:w-full">
+        <div className="CooperateCard relative items-center">
           <svg
-            className="absolute top-0 left-0 s:w-full"
-            width="225"
-            height="128"
-            viewBox="0 0 225 128"
+            className="l:hidden"
+            width="155"
+            height="85"
+            viewBox="0 0 155 85"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
           >
             <rect
               x="0.5"
               y="0.5"
-              className="s:w-full"
-              width="224"
-              height="128"
-              fill="url(#paint0_linear_337:1245)"
-              stroke="url(#paint1_linear_337:1245)"
+              width="153.355"
+              height="83.6677"
+              fill="url(#paint0_linear_618:136)"
+              stroke="url(#paint1_linear_618:136)"
             />
             <defs>
               <linearGradient
-                id="paint0_linear_337:1245"
-                x1="221.018"
-                y1="118.672"
-                x2="13.1176"
-                y2="-17.5004"
+                id="paint0_linear_618:136"
+                x1="151.317"
+                y1="81.3943"
+                x2="9.27881"
+                y2="-11.6396"
                 gradientUnits="userSpaceOnUse"
               >
                 <stop offset="0.0641396" stop-color="white" stop-opacity="0.08" />
                 <stop offset="1" stop-color="white" stop-opacity="0.03" />
               </linearGradient>
               <linearGradient
-                id="paint1_linear_337:1245"
-                x1="205"
-                y1="11"
-                x2="171.194"
-                y2="46.9992"
+                id="paint1_linear_618:136"
+                x1="140.374"
+                y1="7.83205"
+                x2="117.277"
+                y2="32.4268"
                 gradientUnits="userSpaceOnUse"
               >
                 <stop stop-color="#00C6A2" />
@@ -48,8 +47,52 @@ const Cards = () => {
               </linearGradient>
             </defs>
           </svg>
-          {icon}
-          <div className="font-lexend text-lg text-white">{title}</div>
+          <svg
+            className="s:hidden"
+            width="226"
+            height="123"
+            viewBox="0 0 226 123"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              x="0.5"
+              y="0.5"
+              width="225"
+              height="122"
+              fill="url(#paint0_linear_595:4057)"
+              stroke="url(#paint1_linear_595:4057)"
+            />
+            <defs>
+              <linearGradient
+                id="paint0_linear_595:4057"
+                x1="222.004"
+                y1="118.672"
+                x2="13.734"
+                y2="-18.3546"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop offset="0.0641396" stop-color="white" stop-opacity="0.08" />
+                <stop offset="1" stop-color="white" stop-opacity="0.03" />
+              </linearGradient>
+              <linearGradient
+                id="paint1_linear_595:4057"
+                x1="205.915"
+                y1="11"
+                x2="172.118"
+                y2="47.1501"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stop-color="#00C6A2" />
+                <stop offset="1" stop-color="#00BA98" stop-opacity="0" />
+              </linearGradient>
+            </defs>
+          </svg>
+
+          <div className="absolute top-3 items-center flex flex-col w-40 left-1/2 -ml-20">
+            {icon}
+            <div className="font-lexend text-lg text-white">{title}</div>
+          </div>
           <div className="CooperateCard_fake_wrap block absolute top-0 left-0 bottom-0 right-0 z-10 bg-gradient-to-tr hover:bg-none from-black to-gray-900 opacity-70 hover:opacity-100">
             <div className="CooperateCard_fake_arrow "></div>
           </div>

--- a/src/pages/home/Cooperation/const.tsx
+++ b/src/pages/home/Cooperation/const.tsx
@@ -4,7 +4,12 @@ export const cooperations = [
   {
     title: 'NEAR Protocol',
     icon: (
-      <svg className="mb-5" width="48" height="42" viewBox="0 0 48 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg
+        className="l:mb-5 s:mb-2 w-12 s:w-8 h-11 s:h-7"
+        viewBox="0 0 48 42"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path
           fill-rule="evenodd"
           clip-rule="evenodd"
@@ -17,7 +22,14 @@ export const cooperations = [
   {
     title: 'Octopus network',
     icon: (
-      <svg className="mb-2" width="45" height="58" viewBox="0 0 45 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg
+        className="l:mb-5 s:mb-2 w-11 s:w-8 h-14 s:h-9"
+        width="45"
+        height="58"
+        viewBox="0 0 45 58"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path
           fill-rule="evenodd"
           clip-rule="evenodd"
@@ -37,13 +49,19 @@ export const cooperations = [
   },
   {
     title: 'Burrow',
-    icon: <img className="mb-4 w-12 h-12" src="https://i.postimg.cc/4N91SfYW/burrow-avatar-1.png" alt="" />
+    icon: (
+      <img
+        className="mb-4 s:mb-2 s:w-8 s:h-8 w-12 h-12"
+        src="https://i.postimg.cc/4N91SfYW/burrow-avatar-1.png"
+        alt=""
+      />
+    )
   },
   {
     title: 'Skyward Finance',
     icon: (
       <img
-        className="mt-4 m-5 w-40 h-7"
+        className="mt-4 m-5 s:mb-2 w-40 h-7 s:w-28 s:h-5"
         src="//imagev2.xmcdn.com/storages/ff97-audiofreehighqps/32/8D/CKwRIasFRFLWAAAuOwDuJTed.png"
         alt=""
       />
@@ -53,9 +71,7 @@ export const cooperations = [
     title: 'Paras',
     icon: (
       <svg
-        className="mt-4 mb-5"
-        width="110"
-        height="26"
+        className="mt-4 mb-5 s:mb-2 s:w-14 s:h-6 w-28 h-7"
         viewBox="0 0 110 26"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -94,17 +110,25 @@ export const cooperations = [
   },
   {
     title: 'Flux',
-    icon: <img className="-mt-2" width="72" height="72" src="https://i.postimg.cc/rsmgZxvb/image-31-1.png" alt="" />
+    icon: (
+      <img className="-mt-2 s:mb-2 w-20 h-20 s:w-12 s:h-12" src="https://i.postimg.cc/rsmgZxvb/image-31-1.png" alt="" />
+    )
   },
   {
     title: 'Cheddar',
-    icon: <img className="-mt-3 -mb-1 w-20 h-20" src="https://i.postimg.cc/L53RvKFv/cheddy-cheezy-head-1.png" alt="" />
+    icon: (
+      <img
+        className="-mt-3 s:mb-2 -mb-1 s:w-12 s:h-12 w-20 h-20"
+        src="https://i.postimg.cc/L53RvKFv/cheddy-cheezy-head-1.png"
+        alt=""
+      />
+    )
   },
   {
     title: 'Pulse',
     icon: (
       <svg
-        className="mt-3 mb-6"
+        className="mt-3 mb-6 s:mb-2 w-28 h-6 s:w-20 s:h-5"
         width="112"
         height="28"
         viewBox="0 0 112 28"

--- a/src/pages/home/Cooperation/index.scss
+++ b/src/pages/home/Cooperation/index.scss
@@ -19,3 +19,9 @@
     }
   }
 }
+
+@media screen and (min-width: 968px) {
+  .CooperateCard_max_width {
+    width: 976px;
+  }
+}

--- a/src/pages/home/Cooperation/index.tsx
+++ b/src/pages/home/Cooperation/index.tsx
@@ -5,10 +5,19 @@ import './index.scss';
 
 const Cooperation = () => {
   return (
-    <div className="mt-24 w-full l:mt-44">
-      <div className="flex flex-col items-center">
-        <div className="font-poppins font-bold text-6xl italic text-white">Partnerships</div>
-        <div className="mt-5 font-poppins font-bold text-2xl italic text-white">
+    <div className="mt-24 w-full l:mt-44 flex justify-center">
+      <div className="flex flex-col CooperateCard_max_width s:items-center">
+        <div className="font-poppins s:px-2 flex font-bold text-6xl s:text-4xl italic text-white">
+          Partnerships
+          <div
+            className="w-0 h-0 ml-1 -mt-3 border-solid -translate-y-10 inline-block"
+            style={{
+              borderWidth: '0 30px 30px 0',
+              borderColor: 'transparent #00C6A2 transparent transparent'
+            }}
+          />
+        </div>
+        <div className="mt-5 font-poppins font-bold text-2xl s:px-4 italic text-white">
           Many leading projects are already collaborating with Ref.finance,
           <br />
           exploring the next steps for unlocking these exciting benefits!


### PR DESCRIPTION
1. Modify the bottom text.
2. @import the Poppins font.
3. fixed the 'Partnerships' modal  dislocation under the small screen.
4. fixed the 'Partnerships' modal text align left under the Widescreen